### PR TITLE
Fixes slider value update issue when same value is set multiple times

### DIFF
--- a/figma-kit/src/components/slider/slider.tsx
+++ b/figma-kit/src/components/slider/slider.tsx
@@ -54,6 +54,9 @@ const Slider = React.forwardRef<SliderElement, SliderProps>((props, forwardedRef
     }
 
     setTrackedValue(value ?? defaultValue);
+
+    prevValueRef.current = value;
+    prevDefaultValueRef.current = defaultValue;
   }, [value, defaultValue]);
 
   // Radix adjusts the thumb position by default to align with the track edges at min/max positions.


### PR DESCRIPTION
## Issue
When the same value is set multiple times on the Slider component, the slider thumb doesn't visually update after the first change, even though the parent component correctly manages the state. This affects multiple scenarios, including resets and programmatic value changes.

## Root Cause
The Slider component's `useEffect` uses `isDeepEqual` to compare incoming values with previous references, but it doesn't update these references after the comparison. As a result, if the same value is passed multiple times (e.g., the initial value is zero, and we are resetting the component to zero again), the effect's equality check treats it as unchanged, preventing internal state updates.

## Fix
Update the reference values (`prevValueRef.current` and `prevDefaultValueRef.current`) after performing the comparison and state update in the `useEffect` hook. This ensures that all value changes are properly processed, regardless of whether the new value is identical to a previously set value.

```diff
useEffect(() => {
    if (isDeepEqual(value, prevValueRef.current) && isDeepEqual(defaultValue, prevDefaultValueRef.current)) {
      return;
    }

    setTrackedValue(value ?? defaultValue);

+    prevValueRef.current = value;
+    prevDefaultValueRef.current = defaultValue;
  }, [value, defaultValue]);