### PR TITLE
Update the switch to the UI3 styling, fix the submenu and tooltip arrow alignment

### DIFF
--- a/figma-kit/package.json
+++ b/figma-kit/package.json
@@ -1,8 +1,8 @@
 {
-  "name": "figma-kit",
+  "name": "@combdn/figma-kit",
   "description": "A set of React components for building Figma plugins.",
   "homepage": "https://figma-kit.dev",
-  "version": "0.0.0-semantic-release",
+  "version": "1.0.0-beta.19-patch-controls-fixes",
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/figma-kit/src/components/dropdown-menu/dropdown-menu.tsx
+++ b/figma-kit/src/components/dropdown-menu/dropdown-menu.tsx
@@ -87,6 +87,7 @@ const SubContent = React.forwardRef<SubContentElement, SubContentProps>((props, 
         {...subContentProps}
         className={cx(className, 'fp-MenuContent')}
         sideOffset={12}
+        alignOffset={-8}
       />
     </RadixMenu.Portal>
   );

--- a/figma-kit/src/components/switch/switch.css
+++ b/figma-kit/src/components/switch/switch.css
@@ -33,20 +33,22 @@
   &:focus-visible {
     outline-offset: -1px;
     outline: 1px solid var(--figma-color-border-selected-strong);
+
+    &::before {
+      inset: 2px;
+    }
   }
 
-  &:focus-visible::before {
-    inset: 2px;
-  }
+  &[data-disabled] {
+    &[data-state='unchecked']::before {
+      /* This gives it more contrast than the disabled checked state but this is
+      how it is in Figma. ¯\_(ツ)_/¯  */
+      background: var(--figma-color-bg-disabled);
+    }
 
-  &[data-disabled]&[data-state='unchecked']::before {
-    /* This gives it more contrast than the disabled checked state but this is
-    how it is in Figma. ¯\_(ツ)_/¯  */
-    background: var(--figma-color-bg-disabled);
-  }
-
-  &[data-disabled]&[data-state='checked']::before {
-    background: var(--figma-color-bg-tertiary);
+    &[data-state='checked']::before {
+      background: var(--figma-color-bg-tertiary);
+    }
   }
 }
 

--- a/figma-kit/src/components/switch/switch.css
+++ b/figma-kit/src/components/switch/switch.css
@@ -3,33 +3,50 @@
   box-sizing: border-box;
   position: relative;
   display: block;
-  width: var(--space-6);
-  height: var(--space-3);
+  width: var(--space-8);
+  height: var(--space-4);
   padding: 0;
-  background: linear-gradient(90deg, var(--figma-color-bg-brand) 0px 24px, var(--figma-color-icon-tertiary) 24px 48px);
-  background-repeat: no-repeat;
-  background-size: 200% 100%;
+  background: none;
   background-clip: padding-box;
   border-radius: var(--radius-full);
   border: 0;
-  transition: background-position 0.1s ease-out;
+  transition: background-position 0.08s ease-out;
+
+  /* Using ::before to render the background to create the real gap between the
+  outline and the background in the focused mode as it is in Figma.  */
+  &::before {
+    position: absolute;
+    inset: 0;
+    border-radius: var(--radius-full);
+    background: none;
+    content: '';
+  }
+
+  &[data-state='unchecked']::before {
+    background: var(--figma-color-bg-tertiary);
+  }
+
+  &[data-state='checked']::before {
+    background: var(--figma-color-bg-brand);
+  }
 
   &:focus-visible {
-    outline-offset: 2px;
-    outline: 2px solid var(--figma-color-border-selected);
+    outline-offset: -1px;
+    outline: 1px solid var(--figma-color-border-selected-strong);
   }
 
-  &[data-disabled] {
-    background: var(--figma-color-icon-disabled);
-    border-color: var(--figma-color-icon-disabled);
+  &:focus-visible::before {
+    inset: 2px;
   }
 
-  &[data-state='unchecked'] {
-    background-position: -24px;
+  &[data-disabled]&[data-state='unchecked']::before {
+    /* This gives it more contrast than the disabled checked state but this is
+    how it is in Figma. ¯\_(ツ)_/¯  */
+    background: var(--figma-color-bg-disabled);
   }
 
-  &[data-state='checked'] {
-    background-position: 0;
+  &[data-disabled]&[data-state='checked']::before {
+    background: var(--figma-color-bg-tertiary);
   }
 }
 
@@ -38,15 +55,14 @@
   position: absolute;
   top: 1px;
   left: 1px;
-  height: var(--space-2_5);
-  width: var(--space-2_5);
+  height: var(--space-3_5);
+  width: var(--space-3_5);
   border-radius: var(--radius-full);
   background: var(--figma-color-icon-onbrand);
-  transition: all 0.1s ease-out;
+  transition: all 0.08s ease-out;
 
   &[data-disabled] {
-    background-color: var(--figma-color-bg);
-    border-color: var(--figma-color-bg);
+    background-color: var(--figma-color-icon-ondisabled);
   }
 
   &[data-state='unchecked'] {
@@ -54,6 +70,6 @@
   }
 
   &[data-state='checked'] {
-    left: calc(100% - var(--space-2_5) - 1px);
+    left: calc(100% - var(--space-3_5) - 1px);
   }
 }

--- a/figma-kit/src/components/tooltip/tooltip.css
+++ b/figma-kit/src/components/tooltip/tooltip.css
@@ -18,7 +18,7 @@
 .fp-tooltip-arrow {
   fill: var(--color-bg-tooltip);
   width: var(--space-3_5);
-  height: var(--space-1_5);
+  height: 7px;
   position: relative;
   bottom: 1px;
 }

--- a/figma-kit/src/components/tooltip/tooltip.tsx
+++ b/figma-kit/src/components/tooltip/tooltip.tsx
@@ -46,7 +46,7 @@ const Tooltip = React.forwardRef<TooltipElement, TooltipProps>((props, ref) => {
     <RadixTooltip.Root {...rootProps}>
       <RadixTooltip.Trigger asChild>{children}</RadixTooltip.Trigger>
       <RadixTooltip.Portal forceMount={forceMount} container={container}>
-        <Content ref={ref} arrowPadding={10} {...contentProps}>
+        <Content ref={ref} arrowPadding={8} {...contentProps}>
           {content}
           <Arrow />
         </Content>


### PR DESCRIPTION
## Switch

1. UI3 styling with the gap between the focus outline and the background to reproduce the native look.
2. Background offset animation is changed to a simple colour transition (0.08s) to match the native style.

## Submenu Alignment

-8 vertical shift to align the items’ baselines (to match Figma).

## Tooltip Arrow

Update the size and offset to match the native tooltip.