### PR TITLE
fix: letter-spacing variable syntax in text.css

### DIFF
--- a/figma-kit/src/components/text/text.css
+++ b/figma-kit/src/components/text/text.css
@@ -20,7 +20,7 @@
   &:where(.fp-size-medium) {
     --font-size: var(--font-size-3);
     --line-height: var(--line-height-3);
-    --letter-spacing: --letter-spacing-3;
+    --letter-spacing: var(--letter-spacing-3);
   }
 
   &:where(.fp-size-large) {


### PR DESCRIPTION
Add missing `var()` wrapper for `--letter-spacing` in medium size variant.