### PR TITLE
fix: shadow token selectors and missing icon color variable

### DIFF
--- a/figma-kit/src/components/button/button.css
+++ b/figma-kit/src/components/button/button.css
@@ -21,6 +21,7 @@
   letter-spacing: var(--letter-spacing-default);
   line-height: var(--line-height-default);
   border-radius: var(--radius-medium);
+  --color-icon: currentColor;
 }
 
 .fp-Button:where(.fp-variant-secondary) {

--- a/figma-kit/src/styles/tokens/shadow.css
+++ b/figma-kit/src/styles/tokens/shadow.css
@@ -1,4 +1,6 @@
-:root {
+:root,
+.light,
+.light-theme {
   --elevation-100: 0px 0px 0.5px rgba(0, 0, 0, 0.3), 0px 1px 3px rgba(0, 0, 0, 0.15);
   --elevation-200: 0px 0px 0.5px rgba(0, 0, 0, 0.18), 0px 3px 8px rgba(0, 0, 0, 0.1), 0px 1px 3px rgba(0, 0, 0, 0.1);
   --elevation-300: 0px 0px 0.5px rgba(0, 0, 0, 0.15), 0px 5px 12px rgba(0, 0, 0, 0.13), 0px 1px 3px rgba(0, 0, 0, 0.1);
@@ -6,8 +8,8 @@
   --elevation-500: 0px 0px 0.5px rgba(0, 0, 0, 0.08), 0px 10px 24px rgba(0, 0, 0, 0.18), 0px 2px 5px rgba(0, 0, 0, 0.15);
 }
 
-.dark,
-.dark-theme {
+
+.figma-dark {
   --elevation-100: 0px 0px 0.5px rgba(0, 0, 0, 0.5), 0px 1px 3px rgba(0, 0, 0, 0.4),
     inset 0px 0.5px 0px rgba(255, 255, 255, 0.1), inset 0px 0px 0.5px rgba(255, 255, 255, 0.3);
 


### PR DESCRIPTION
- Fix shadow token selectors for light and dark themes.
- Define `--color-icon` on buttons so child icons resolve.