### PR TITLE
fix: keep sub-menu parent highlighted while open

### DIFF
--- a/figma-kit/src/components/menu.base/menu.base.css
+++ b/figma-kit/src/components/menu.base/menu.base.css
@@ -30,6 +30,15 @@
     background-color: var(--color-bg-menu-selected);
   }
 
+  /* Sub-menu parent when open and not hovered */
+  &[data-state='open'] {
+    background-color: var(--color-bg-menu-selected-parent);
+
+    &[data-highlighted] {
+      background-color: var(--color-bg-menu-selected);
+    }
+  }
+
   &[data-disabled] {
     color: var(--color-text-menu-tertiary);
   }

--- a/figma-kit/src/styles/tokens/components.css
+++ b/figma-kit/src/styles/tokens/components.css
@@ -2,6 +2,7 @@
   --color-bg-menu: #1e1e1e;
   --color-bg-menu-hover: #2c2c2c;
   --color-bg-menu-selected: var(--figma-color-bg-selected-strong);
+  --color-bg-menu-selected-parent: #ffffff0d;
   --color-border-menu: #383838;
   --color-text-menu: var(--figma-color-text-oncomponent);
   --color-text-menu-secondary: var(--figma-color-text-oncomponent-secondary);


### PR DESCRIPTION
- Keep a sub-menu parent item visually highlighted while its child menu is open.
- Restore the normal selected highlight when the open parent is hovered/highlighted.

The new menu-specific color token is sampled from Figma’s UI. I could not find a matching semantic color token in the official `--figma-color-*` variables for this open-parent state, so happy to adjust if there is a preferred styling approach.